### PR TITLE
fix NULL when end of file occurs

### DIFF
--- a/pmparser.c
+++ b/pmparser.c
@@ -41,8 +41,10 @@ procmaps_iterator* pmparser_parse(int pid){
 	char addr1[20],addr2[20], perm[8], offset[20], dev[10],inode[30],pathname[PATH_MAX];
 	while( !feof(file) ){
 		if (fgets(buf,PROCMAPS_LINE_MAX_LENGTH,file) == NULL){
-			fprintf(stderr,"pmparser : fgets failed, %s\n",strerror(errno));
-			return NULL;
+			if (errno != 0){
+				fprintf(stderr, "pmparser : fgets failed, %s\n", strerror(errno));
+				return NULL;
+			}
 		}
 		//allocate a node
 		tmp=(procmaps_struct*)malloc(sizeof(procmaps_struct));

--- a/pmparser.c
+++ b/pmparser.c
@@ -40,11 +40,9 @@ procmaps_iterator* pmparser_parse(int pid){
 	procmaps_struct* current_node=list_maps;
 	char addr1[20],addr2[20], perm[8], offset[20], dev[10],inode[30],pathname[PATH_MAX];
 	while( !feof(file) ){
-		if (fgets(buf,PROCMAPS_LINE_MAX_LENGTH,file) == NULL){
-			if (errno != 0){
-				fprintf(stderr, "pmparser : fgets failed, %s\n", strerror(errno));
-				return NULL;
-			}
+		if (fgets(buf,PROCMAPS_LINE_MAX_LENGTH,file) == NULL && errno){
+			fprintf(stderr,"pmparser : fgets failed, %s\n",strerror(errno));
+			return NULL;
 		}
 		//allocate a node
 		tmp=(procmaps_struct*)malloc(sizeof(procmaps_struct));


### PR DESCRIPTION
fgets() returns s on success, and NULL on error or when end of file occurs while no characters have been read.