### PR TITLE
procmaps_parser V2 - Rework and improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-
+CFLAGS=-std=gnu99 -pedantic  -Wall
 
 SRC_DIR = $(shell pwd)
 export BUILD_DIR ?= $(SRC_DIR)/build
@@ -7,7 +7,7 @@ export INCLUDE_DIR = $(SRC_DIR)/include
 .PHONY: pmparser
 pmparser:
 	mkdir -p $(BUILD_DIR) && \
-	$(CC) $(SRC_DIR)/$@.c -I$(INCLUDE_DIR) -c -o $(BUILD_DIR)/$@.o && \
+	$(CC) $(SRC_DIR)/$@.c $(CFLAGS) -I$(INCLUDE_DIR) -c -o $(BUILD_DIR)/$@.o && \
 	ar rcs $(BUILD_DIR)/lib$@.a $(BUILD_DIR)/$@.o
 
 

--- a/examples/map.c
+++ b/examples/map.c
@@ -1,32 +1,105 @@
-#include <pmparser.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "pmparser.h"
 
 /**
-* 
-* Usage: map [pid]
-*/
+ * pmparser_print
+ * @param mem_reg memory region to display
+ */
+void pmparser_print(procmaps_struct *mem_reg);
 
-int main(int argc, char* argv[]){
-	int pid;
-	if(argc==2) pid=atoi(argv[1]);
-	else pid=-1;
+const char *map_type_to_string(procmaps_map_type type);
+/**
+ *
+ * Usage: map [pid]
+ */
 
-	procmaps_iterator* maps = pmparser_parse(pid);
-	if(maps==NULL){
-		printf ("[map]: cannot parse the memory map of %d\n",pid);
+int main(int argc, char *argv[])
+{
+	int pid = -1;
+	procmaps_iterator maps_iter = {0};
+	procmaps_error_t parser_err = PROCMAPS_SUCCESS;
+
+	if (argc == 2)
+		pid = atoi(argv[1]);
+	else
+		pid = -1;
+
+	parser_err = pmparser_parse(pid, &maps_iter);
+	if (parser_err)
+	{
+		printf("[proc_maps_parser]: failure to parse the memory map of process %d (error=%d)\n", pid, (int)parser_err);
 		return -1;
 	}
 
-	//iterate over areas
-	procmaps_struct* maps_tmp=NULL;
-	
-	while( (maps_tmp = pmparser_next(maps)) != NULL){
-		pmparser_print(maps_tmp,0);
-		printf("\n~~~~~~~~~~~~~~~~~~~~~~~~~\n"); 
+	// iterate over areas
+	procmaps_struct *mem_region = NULL;
+
+	while ((mem_region = pmparser_next(&maps_iter)) != NULL)
+	{
+		pmparser_print(mem_region);
 	}
 
-	//mandatory: should free the list
-	pmparser_free(maps);
+	// mandatory: should free the list
+	pmparser_free(&maps_iter);
 
 	return 0;
+}
 
+void pmparser_print(procmaps_struct *mem_reg)
+{
+	printf("0x%.12lx-0x%.12lx\t", (size_t)mem_reg->addr_start, (size_t)mem_reg->addr_end);
+	printf("%c%c%c%c ", mem_reg->is_r ? 'r' : '-', mem_reg->is_w ? 'w' : '-', mem_reg->is_x ? 'x' : '-', mem_reg->is_p ? 'p' : 's');
+	printf("%ld\n", mem_reg->length);
+	printf("%s\t", map_type_to_string(mem_reg->map_type));
+	if (mem_reg->map_type == PROCMAPS_MAP_FILE)
+	{
+		printf("Offset:%ld ", mem_reg->offset);
+		printf("%s", mem_reg->pathname);
+	}
+	else if (mem_reg->map_type == PROCMAPS_MAP_ANON_PRIV || mem_reg->map_type == PROCMAPS_MAP_ANON_SHMEM)
+	{
+		printf("%s", mem_reg->map_anon_name);
+	}
+	else if (mem_reg->map_type == PROCMAPS_MAP_OTHER)
+	{
+		printf("%s", mem_reg->pathname);
+	}
+	printf("\n");
+	printf("inode :%llu\ndevice:%u:%u", mem_reg->inode, mem_reg->dev_major, mem_reg->dev_minor);
+	printf("\n\n");
+}
+
+const char *map_type_to_string(procmaps_map_type type)
+{
+	switch (type)
+	{
+	case PROCMAPS_MAP_FILE:
+		return "file";
+	case PROCMAPS_MAP_STACK:
+		return "process_stack";
+	case PROCMAPS_MAP_STACK_TID:
+		return "thread_stack";
+	case PROCMAPS_MAP_VDSO:
+		return "VDSO";
+	case PROCMAPS_MAP_HEAP:
+		return "heap";
+	case PROCMAPS_MAP_ANON_PRIV:
+		return "anon_private";
+	case PROCMAPS_MAP_ANON_SHMEM:
+		return "anon_shared";
+	case PROCMAPS_MAP_ANON_MMAPS:
+		return "anonymous";
+	case PROCMAPS_MAP_VVAR:
+		return "vvar";
+	case PROCMAPS_MAP_VSYSCALL:
+		return "vsyscall";
+	case PROCMAPS_MAP_OTHER:
+		return "other";
+	default:
+		return "unknown";
+	}
 }

--- a/include/pmparser.h
+++ b/include/pmparser.h
@@ -1,5 +1,5 @@
 /*
- @Author	: ouadimjamal@gmail.com
+ @Author	: ouadev
  @date		: December 2015
 
 Permission to use, copy, modify, distribute, and sell this software and its
@@ -14,56 +14,86 @@ implied warranty.
 
 #ifndef H_PMPARSER
 #define H_PMPARSER
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <linux/limits.h>
 
-//maximum line length in a procmaps file
-#define PROCMAPS_LINE_MAX_LENGTH  (PATH_MAX + 100) 
+// Documentation link: https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html
+
+// maximum length of the name of an anonymous mapping
+#define MAPPING_ANON_NAME_MAX_LEN 80
+
+/**
+ * @brief Type of a memory's region mapping.
+ *
+ */
+typedef enum
+{
+	PROCMAPS_MAP_FILE,
+	PROCMAPS_MAP_STACK,
+	PROCMAPS_MAP_STACK_TID,
+	PROCMAPS_MAP_VDSO,
+	PROCMAPS_MAP_VVAR,
+	PROCMAPS_MAP_VSYSCALL,
+	PROCMAPS_MAP_HEAP,
+	PROCMAPS_MAP_ANON_PRIV,
+	PROCMAPS_MAP_ANON_SHMEM,
+	PROCMAPS_MAP_ANON_MMAPS,
+	PROCMAPS_MAP_OTHER,
+} procmaps_map_type;
+
 /**
  * procmaps_struct
  * @desc hold all the information about an area in the process's  VM
  */
-typedef struct procmaps_struct{
-	void* addr_start; 	//< start address of the area
-	void* addr_end; 	//< end address
-	unsigned long length; //< size of the range
-
-	char perm[5];		//< permissions rwxp
-	short is_r;			//< rewrote of perm with short flags
+typedef struct procmaps_struct
+{
+	void *addr_start; //< start address of the area
+	void *addr_end;	  //< end address
+	size_t length;	  //< size of the range
+	short is_r;
 	short is_w;
 	short is_x;
 	short is_p;
-
-	long offset;	//< offset
-	char dev[12];	//< dev major:minor
-	int inode;		//< inode of the file that backs the area
-
-	char pathname[600];		//< the path of the file that backs the area
-	//chained list
-	struct procmaps_struct* next;		//<handler of the chinaed list
+	size_t offset; //< offset
+	unsigned int dev_major;
+	unsigned int dev_minor;
+	unsigned long long inode; //< inode of the file that backs the area
+	char *pathname;			  //< the path of the file that backs the area ( dynamically allocated)
+	procmaps_map_type map_type;
+	char map_anon_name[MAPPING_ANON_NAME_MAX_LEN + 1]; //< name of the anonymous mapping in case map_type is an anon mapping
+	short file_deleted;								   //< whether the file backing the mapping was deleted
+	// chained list
+	struct procmaps_struct *next; //<handler of the chained list
 } procmaps_struct;
+
+/**
+ * @brief procmaps error type
+ *
+ */
+typedef enum procmaps_error
+{
+	PROCMAPS_SUCCESS = 0,
+	PROCMAPS_ERROR_OPEN_MAPS_FILE,
+	PROCMAPS_ERROR_READ_MAPS_FILE,
+	PROCMAPS_ERROR_MALLOC_FAIL,
+} procmaps_error_t;
 
 /**
  * procmaps_iterator
  * @desc holds iterating information
  */
-typedef struct procmaps_iterator{
-	procmaps_struct* head;
-	procmaps_struct* current;
+typedef struct procmaps_iterator
+{
+	procmaps_struct *head;
+	procmaps_struct *current;
+	size_t count;
 } procmaps_iterator;
+
 /**
- * pmparser_parse
- * @param pid the process id whose memory map to be parser. the current process if pid<0
- * @return an iterator over all the nodes
+ * @brief Main function to parse process memory
+ * @param pid process ID
+ * @param maps_it output : the memory region iterator over the chained list, t should only be read when return is 0.
+ * @return procmaps_error_t outcome of the function
  */
-procmaps_iterator* pmparser_parse(int pid);
+procmaps_error_t pmparser_parse(int pid, procmaps_iterator *maps_it);
 
 /**
  * pmparser_next
@@ -71,29 +101,12 @@ procmaps_iterator* pmparser_parse(int pid);
  * @param p_procmaps_it the iterator to move on step in the chained list
  * @return a procmaps structure filled with information about this VM area
  */
-procmaps_struct* pmparser_next(procmaps_iterator* p_procmaps_it);
+procmaps_struct *pmparser_next(procmaps_iterator *p_procmaps_it);
 /**
  * pmparser_free
  * @description should be called at the end to free the resources
  * @param p_procmaps_it the iterator structure returned by pmparser_parse
  */
-void pmparser_free(procmaps_iterator* p_procmaps_it);
-
-/**
- * _pmparser_split_line
- * @description internal usage
- */
-void _pmparser_split_line(char*buf,char*addr1,char*addr2,char*perm, char* offset, char* device,char*inode,char* pathname);
-
-/**
- * pmparser_print
- * @param map the head of the list
- * @order the order of the area to print, -1 to print everything
- */
-void pmparser_print(procmaps_struct* map,int order);
-
-
-
-
+void pmparser_free(procmaps_iterator *p_procmaps_it);
 
 #endif

--- a/pmparser.c
+++ b/pmparser.c
@@ -1,5 +1,5 @@
 /*
- @Author	: ouadimjamal@gmail.com
+ @Author	: ouadev
  @date		: December 2015
 
 Permission to use, copy, modify, distribute, and sell this software and its
@@ -10,218 +10,292 @@ documentation.  No representations are made about the suitability of this
 software for any purpose.  It is provided "as is" without express or
 implied warranty.
 */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include <pmparser.h>
+#include "pmparser.h"
+
+// maximum line length in a procmaps file
+#define PROCMAPS_LINE_INIT_LENGTH (300)
+// maximum length of the path of a maps file : /proc/[pid]/maps
+#define PROCMAPS_MAPS_FILE_PATH_MAX_LENGTH 30
+// maximum token size while parsing the proc/pid/maps
+#define PROCMAPS_LINE_TOKEN_MAX_LEN 100
 
 /**
- * gobal variables
+ * pmparser_parse_line
+ * @description internal usage
  */
-//procmaps_struct* g_last_head=NULL;
-//procmaps_struct* g_current=NULL;
+static void pmparser_parse_line(char *buf, procmaps_struct *mem_reg);
 
+/**
+ * @brief Copy into dest_ptr the string from src_ptr to the first occurence of delimiter
+ */
+static char *pmparser_helper_extract(char *src_ptr, const char *delimiter, char *dest_ptr);
 
-procmaps_iterator* pmparser_parse(int pid){
-	procmaps_iterator* maps_it = malloc(sizeof(procmaps_iterator));
-	char maps_path[500];
-	if(pid>=0 ){
-		sprintf(maps_path,"/proc/%d/maps",pid);
-	}else{
-		sprintf(maps_path,"/proc/self/maps");
+/**
+ * @brief Main function to parse process memory
+ *
+ * @param pid process ID
+ * @param maps_it output : the memory region iterator over the chained list, it should only be read when return is 0
+ * @return procmaps_error_t outcome of the function
+ */
+procmaps_error_t pmparser_parse(int pid, procmaps_iterator *maps_it)
+{
+	char maps_path[PROCMAPS_MAPS_FILE_PATH_MAX_LENGTH];
+	size_t line_len = 0;
+	char *line_ptr = NULL;
+	procmaps_struct *mem_reg = NULL;
+	procmaps_struct *tail_node = NULL;
+	procmaps_struct *head_node = NULL;
+	size_t node_count = 0;
+
+	if (pid >= 0)
+	{
+		snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid);
 	}
-	FILE* file=fopen(maps_path,"r");
-	if(!file){
-		fprintf(stderr,"pmparser : cannot open the memory maps, %s\n",strerror(errno));
-		return NULL;
+	else
+	{
+		sprintf(maps_path, "/proc/self/maps");
 	}
-	int ind=0;char buf[PROCMAPS_LINE_MAX_LENGTH];
-	int c;
-	procmaps_struct* list_maps=NULL;
-	procmaps_struct* tmp;
-	procmaps_struct* current_node=list_maps;
-	char addr1[20],addr2[20], perm[8], offset[20], dev[10],inode[30],pathname[PATH_MAX];
-	while( !feof(file) ){
-		if (fgets(buf,PROCMAPS_LINE_MAX_LENGTH,file) == NULL && errno){
-			fprintf(stderr,"pmparser : fgets failed, %s\n",strerror(errno));
-			return NULL;
+
+	FILE *file = fopen(maps_path, "r");
+	if (!file)
+	{
+		return PROCMAPS_ERROR_OPEN_MAPS_FILE;
+	}
+
+	// scan maps file line by line
+	line_len = PROCMAPS_LINE_INIT_LENGTH;
+	if ((line_ptr = (char *)malloc(line_len)) == NULL)
+	{
+		fclose(file);
+		return PROCMAPS_ERROR_MALLOC_FAIL;
+	}
+
+	while (1)
+	{
+		int read = getline(&line_ptr, &line_len, file);
+		if (read == -1)
+		{
+			if (!feof(file))
+			{
+				return PROCMAPS_ERROR_READ_MAPS_FILE;
+			}
+			else
+			{
+				// end of file occured while no characters have been read
+				break;
+			}
 		}
-		//allocate a node
-		tmp=(procmaps_struct*)malloc(sizeof(procmaps_struct));
-		//fill the node
-		_pmparser_split_line(buf,addr1,addr2,perm,offset, dev,inode,pathname);
-		//printf("#%s",buf);
-		//printf("%s-%s %s %s %s %s\t%s\n",addr1,addr2,perm,offset,dev,inode,pathname);
-		//addr_start & addr_end
-		unsigned long l_addr_start;
-		sscanf(addr1,"%lx",(long unsigned *)&tmp->addr_start );
-		sscanf(addr2,"%lx",(long unsigned *)&tmp->addr_end );
-		//size
-		tmp->length=(unsigned long)(tmp->addr_end-tmp->addr_start);
-		//perm
-		strcpy(tmp->perm,perm);
-		tmp->is_r=(perm[0]=='r');
-		tmp->is_w=(perm[1]=='w');
-		tmp->is_x=(perm[2]=='x');
-		tmp->is_p=(perm[3]=='p');
 
-		//offset
-		sscanf(offset,"%lx",&tmp->offset );
-		//device
-		strcpy(tmp->dev,dev);
-		//inode
-		tmp->inode=atoi(inode);
-		//pathname
-		strcpy(tmp->pathname,pathname);
-		tmp->next=NULL;
-		//attach the node
-		if(ind==0){
-			list_maps=tmp;
-			list_maps->next=NULL;
-			current_node=list_maps;
+		// allocate a node
+		mem_reg = (procmaps_struct *)malloc(sizeof(procmaps_struct));
+		// fill the node
+		pmparser_parse_line(line_ptr, mem_reg);
+		mem_reg->next = NULL;
+
+		// Attach the node
+		if (tail_node == NULL)
+		{
+			head_node = tail_node = mem_reg;
 		}
-		current_node->next=tmp;
-		current_node=tmp;
-		ind++;
-		//printf("%s",buf);
+		else
+		{
+			tail_node->next = mem_reg;
+			tail_node = mem_reg;
+		}
+		node_count++;
 	}
 
-	//close file
+	// close file
 	fclose(file);
+	free(line_ptr);
 
+	// set iterator
+	maps_it->head = maps_it->current = head_node;
+	maps_it->count = node_count;
 
-	//g_last_head=list_maps;
-	maps_it->head = list_maps;
-	maps_it->current =  list_maps;
-	return maps_it;
+	return PROCMAPS_SUCCESS;
 }
 
-
-procmaps_struct* pmparser_next(procmaps_iterator* p_procmaps_it){
-	if(p_procmaps_it->current == NULL)
+/**
+ * @brief move the iterator to the next memory region
+ *
+ * @param p_procmaps_it
+ * @return procmaps_struct*
+ */
+procmaps_struct *pmparser_next(procmaps_iterator *p_procmaps_it)
+{
+	if (p_procmaps_it->current == NULL)
 		return NULL;
-	procmaps_struct* p_current = p_procmaps_it->current;
+	procmaps_struct *p_current = p_procmaps_it->current;
 	p_procmaps_it->current = p_procmaps_it->current->next;
 	return p_current;
-	/*
-	if(g_current==NULL){
-		g_current=g_last_head;
-	}else
-		g_current=g_current->next;
-
-	return g_current;
-	*/
 }
 
+/**
+ * @brief free the parser data
+ *
+ * @param p_procmaps_it
+ */
+void pmparser_free(procmaps_iterator *p_procmaps_it)
+{
+	procmaps_struct *cursor = p_procmaps_it->head;
+	procmaps_struct *next = NULL;
 
+	if (p_procmaps_it->head == NULL)
+		return;
 
-void pmparser_free(procmaps_iterator* p_procmaps_it){
-	procmaps_struct* maps_list = p_procmaps_it->head;
-	if(maps_list==NULL) return ;
-	procmaps_struct* act=maps_list;
-	procmaps_struct* nxt=act->next;
-	while(act!=NULL){
-		free(act);
-		act=nxt;
-		if(nxt!=NULL)
-			nxt=nxt->next;
+	while (cursor != NULL)
+	{
+		next = cursor->next;
+		free(cursor->pathname);
+		free(cursor);
+		cursor = next;
 	}
-	free(p_procmaps_it);
+	memset(p_procmaps_it, 0x00, sizeof(procmaps_iterator));
 }
 
+static char *pmparser_helper_extract(char *src_ptr, const char *delimiter, char *dest_ptr)
+{
+	char *p_separator = NULL;
+	size_t copy_len = 0;
 
-void _pmparser_split_line(
-		char*buf,char*addr1,char*addr2,
-		char*perm,char* offset,char* device,char*inode,
-		char* pathname){
-	//
-	int orig=0;
-	int i=0;
-	//addr1
-	while(buf[i]!='-'){
-		addr1[i-orig]=buf[i];
-		i++;
-	}
-	addr1[i]='\0';
-	i++;
-	//addr2
-	orig=i;
-	while(buf[i]!='\t' && buf[i]!=' '){
-		addr2[i-orig]=buf[i];
-		i++;
-	}
-	addr2[i-orig]='\0';
+	p_separator = strstr(src_ptr, delimiter);
+	copy_len = (p_separator - src_ptr);
+	memcpy(dest_ptr, src_ptr, copy_len);
+	dest_ptr[copy_len] = 0x00;
 
-	//perm
-	while(buf[i]=='\t' || buf[i]==' ')
-		i++;
-	orig=i;
-	while(buf[i]!='\t' && buf[i]!=' '){
-		perm[i-orig]=buf[i];
-		i++;
-	}
-	perm[i-orig]='\0';
-	//offset
-	while(buf[i]=='\t' || buf[i]==' ')
-		i++;
-	orig=i;
-	while(buf[i]!='\t' && buf[i]!=' '){
-		offset[i-orig]=buf[i];
-		i++;
-	}
-	offset[i-orig]='\0';
-	//dev
-	while(buf[i]=='\t' || buf[i]==' ')
-		i++;
-	orig=i;
-	while(buf[i]!='\t' && buf[i]!=' '){
-		device[i-orig]=buf[i];
-		i++;
-	}
-	device[i-orig]='\0';
-	//inode
-	while(buf[i]=='\t' || buf[i]==' ')
-		i++;
-	orig=i;
-	while(buf[i]!='\t' && buf[i]!=' '){
-		inode[i-orig]=buf[i];
-		i++;
-	}
-	inode[i-orig]='\0';
-	//pathname
-	pathname[0]='\0';
-	while(buf[i]=='\t' || buf[i]==' ')
-		i++;
-	orig=i;
-	while(buf[i]!='\t' && buf[i]!=' ' && buf[i]!='\n'){
-		pathname[i-orig]=buf[i];
-		i++;
-	}
-	pathname[i-orig]='\0';
-
+	return p_separator;
 }
 
-void pmparser_print(procmaps_struct* map, int order){
+static void pmparser_parse_line(char *buf, procmaps_struct *mem_reg)
+{
+	char token[PROCMAPS_LINE_TOKEN_MAX_LEN];
+	size_t pathname_len = 0;
+	char *p_cursor = buf;
 
-	procmaps_struct* tmp=map;
-	int id=0;
-	if(order<0) order=-1;
-	while(tmp!=NULL){
-		//(unsigned long) tmp->addr_start;
-		if(order==id || order==-1){
-			printf("Backed by:\t%s\n",strlen(tmp->pathname)==0?"[anonym*]":tmp->pathname);
-			printf("Range:\t\t%p-%p\n",tmp->addr_start,tmp->addr_end);
-			printf("Length:\t\t%ld\n",tmp->length);
-			printf("Offset:\t\t%ld\n",tmp->offset);
-			printf("Permissions:\t%s\n",tmp->perm);
-			printf("Inode:\t\t%d\n",tmp->inode);
-			printf("Device:\t\t%s\n",tmp->dev);
+	// addr1
+	p_cursor = pmparser_helper_extract(p_cursor, "-", token);
+	p_cursor++;
+
+	sscanf(token, "%lx", (long unsigned *)&mem_reg->addr_start);
+
+	// addr2
+	p_cursor = pmparser_helper_extract(p_cursor, " ", token);
+	p_cursor++;
+
+	sscanf(token, "%lx", (long unsigned *)&mem_reg->addr_end);
+
+	// region size
+	mem_reg->length = (unsigned long)((char*)mem_reg->addr_end - (char*)mem_reg->addr_start);
+
+	// perm
+	p_cursor = pmparser_helper_extract(p_cursor, " ", token);
+	p_cursor++;
+
+	mem_reg->is_r = (token[0] == 'r');
+	mem_reg->is_w = (token[1] == 'w');
+	mem_reg->is_x = (token[2] == 'x');
+	mem_reg->is_p = (token[3] == 'p');
+
+	// offset
+	p_cursor = pmparser_helper_extract(p_cursor, " ", token);
+	p_cursor++;
+
+	sscanf(token, "%lx", &mem_reg->offset);
+
+	// dev
+	p_cursor = pmparser_helper_extract(p_cursor, " ", token);
+	p_cursor++;
+
+	sscanf(token, "%u:%u", &mem_reg->dev_major, &mem_reg->dev_minor);
+
+	// inode
+	p_cursor = pmparser_helper_extract(p_cursor, " ", token);
+	p_cursor++;
+
+	sscanf(token, "%llu", &mem_reg->inode);
+
+	// pathname
+	// find the start of the pathname
+	while (*p_cursor == '\t' || *p_cursor == ' ')
+		p_cursor++;
+	// calculate its size
+	char *ptr_sz = p_cursor;
+	while (*ptr_sz != '\n')
+	{
+		ptr_sz++;
+	}
+	pathname_len = (ptr_sz - p_cursor);
+	// copy it
+	mem_reg->pathname = (char *)malloc(pathname_len * sizeof(char) + 1);
+	memcpy(mem_reg->pathname, p_cursor, pathname_len);
+	mem_reg->pathname[pathname_len] = 0x00;
+
+	// Pathname decoding
+	if (mem_reg->pathname[0] == 0x00)
+	{
+		// empty path name
+		mem_reg->map_type = PROCMAPS_MAP_ANON_MMAPS;
+	}
+	else if (strncmp(mem_reg->pathname, "[stack]", 7) == 0)
+	{
+		// mapping backed by main thread stack
+		mem_reg->map_type = PROCMAPS_MAP_STACK;
+	}
+	else if (strncmp(mem_reg->pathname, "[stack:", 7) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_STACK_TID;
+	}
+	else if (strncmp(mem_reg->pathname, "[vdso]", 6) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_VDSO;
+	}
+	else if (strncmp(mem_reg->pathname, "[heap]", 6) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_HEAP;
+	}
+	else if (strncmp(mem_reg->pathname, "[anon:", 6) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_ANON_PRIV;
+		pmparser_helper_extract(mem_reg->pathname + 6, "]", token);
+		strncpy(mem_reg->map_anon_name, token, MAPPING_ANON_NAME_MAX_LEN);
+	}
+	else if (strncmp(mem_reg->pathname, "[anon_shmem:", 12) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_ANON_SHMEM;
+		pmparser_helper_extract(mem_reg->pathname + 12, "]", token);
+		strncpy(mem_reg->map_anon_name, token, MAPPING_ANON_NAME_MAX_LEN);
+	}
+	else if (strncmp(mem_reg->pathname, "[vvar]", 6) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_VVAR;
+	}
+	else if (strncmp(mem_reg->pathname, "[vsyscall]", 10) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_VSYSCALL;
+	}
+	else if (strncmp(mem_reg->pathname, "[", 1) == 0)
+	{
+		mem_reg->map_type = PROCMAPS_MAP_OTHER;
+	}
+	else
+	{
+		// file backed mapping then
+		mem_reg->map_type = PROCMAPS_MAP_FILE;
+
+		// is the file deleted ?
+		// file_deleted
+		if (memcmp(mem_reg->pathname + strlen(mem_reg->pathname) - 9, "(deleted)", 9) == 0)
+		{
+			mem_reg->file_deleted = 1;
 		}
-		if(order!=-1 && id>order)
-			tmp=NULL;
-		else if(order==-1){
-			printf("#################################\n");
-			tmp=tmp->next;
-		}else tmp=tmp->next;
-
-		id++;
+		else
+		{
+			mem_reg->file_deleted = 0;
+		}
 	}
 }


### PR DESCRIPTION
+ add error types
+ improve procmaps data types
+ improve parsing and pathname memory allocation
+ improve the example
+ support more memory mapping regions
+ add a flag to indicate if a region's backing file is deleted
+ improve linked list code
+ bugfix : errno is not reset between two successive calls
+ bugfix : double free